### PR TITLE
Always return scalar from aggregate

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1428,8 +1428,6 @@ class Builder {
 
 		$total = $this->count();
 
-		if (is_array($total)) $total = count($total);
-
 		$this->restoreFieldsForCount();
 
 		return $total;
@@ -1564,7 +1562,7 @@ class Builder {
 	 * Retrieve the "count" result of the query.
 	 *
 	 * @param  string  $columns
-	 * @return array|int
+	 * @return int
 	 */
 	public function count($columns = '*')
 	{
@@ -1575,7 +1573,7 @@ class Builder {
 
 		$count = $this->aggregate(__FUNCTION__, $columns);
 
-		return is_array($count) ? array_map('intval', $count) : (int) $count;
+		return is_array($count) ? count($count) : (int) $count;
 	}
 
 	/**
@@ -1586,7 +1584,9 @@ class Builder {
 	 */
 	public function min($column)
 	{
-		return $this->aggregate(__FUNCTION__, array($column));
+		$result = $this->aggregate(__FUNCTION__, array($column));
+
+		return is_array($result) ? min($result) : $result;
 	}
 
 	/**
@@ -1597,7 +1597,9 @@ class Builder {
 	 */
 	public function max($column)
 	{
-		return $this->aggregate(__FUNCTION__, array($column));
+		$result = $this->aggregate(__FUNCTION__, array($column));
+
+		return is_array($result) ? max($result) : $result;
 	}
 
 	/**
@@ -1610,7 +1612,7 @@ class Builder {
 	{
 		$result = $this->aggregate(__FUNCTION__, array($column));
 
-		return $result ?: 0;
+		return is_array($result) ? array_sum($result) : $result ?: 0;
 	}
 
 	/**
@@ -1621,7 +1623,14 @@ class Builder {
 	 */
 	public function avg($column)
 	{
-		return $this->aggregate(__FUNCTION__, array($column));
+		$result = $this->aggregate(__FUNCTION__, array($column));
+
+		if (is_array($result))
+		{
+			return $result ? array_sum($result) / count($result) : 0;
+		}
+
+		return $result ?: 0;
 	}
 
 	/**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -845,28 +845,40 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testAggregateFunctionsWithGroups()
 	{
 		$builder = $this->getBuilder();
-		$builder->getConnection()->shouldReceive('select')->once()->with('select count(*) as aggregate from "users" group by "name"', array(), true)->andReturn(array(array('aggregate' => '3'), array('Aggregate' => '2')));
+		$builder->getConnection()->shouldReceive('select')->once()->with('select count(*) as aggregate from "users" group by "name"', array(), true)->andReturn(array(array('aggregate' => '3'), array('Aggregate' => '4')));
 		$builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function($builder, $results) { return $results; });
 		$results = $builder->from('users')->groupBy('name')->count();
-		$this->assertSame(array(3, 2), $results);
+		$this->assertEquals(2, $results);
 
 		$builder = $this->getBuilder();
-		$builder->getConnection()->shouldReceive('select')->once()->with('select max("id") as aggregate from "users" group by "name"', array(), true)->andReturn(array(array('aggregate' => 3), array('aggregate' => 2)));
+		$builder->getConnection()->shouldReceive('select')->once()->with('select max("id") as aggregate from "users" group by "name"', array(), true)->andReturn(array(array('aggregate' => 3), array('aggregate' => 4)));
 		$builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function($builder, $results) { return $results; });
 		$results = $builder->from('users')->groupBy('name')->max('id');
-		$this->assertEquals(array(3, 2), $results);
+		$this->assertEquals(4, $results);
 
 		$builder = $this->getBuilder();
-		$builder->getConnection()->shouldReceive('select')->once()->with('select min("id") as aggregate from "users" group by "name"', array(), true)->andReturn(array(array('aggregate' => 3), array('aggregate' => 2)));
+		$builder->getConnection()->shouldReceive('select')->once()->with('select min("id") as aggregate from "users" group by "name"', array(), true)->andReturn(array(array('aggregate' => 3), array('aggregate' => 4)));
 		$builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function($builder, $results) { return $results; });
 		$results = $builder->from('users')->groupBy('name')->min('id');
-		$this->assertEquals(array(3, 2), $results);
+		$this->assertEquals(3, $results);
 
 		$builder = $this->getBuilder();
-		$builder->getConnection()->shouldReceive('select')->once()->with('select sum("id") as aggregate from "users" group by "name"', array(), true)->andReturn(array(array('aggregate' => 3), array('aggregate' => 2)));
+		$builder->getConnection()->shouldReceive('select')->once()->with('select sum("id") as aggregate from "users" group by "name"', array(), true)->andReturn(array(array('aggregate' => 3), array('aggregate' => 4)));
 		$builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function($builder, $results) { return $results; });
 		$results = $builder->from('users')->groupBy('name')->sum('id');
-		$this->assertEquals(array(3, 2), $results);
+		$this->assertEquals(7, $results);
+
+		$builder = $this->getBuilder();
+		$builder->getConnection()->shouldReceive('select')->once()->with('select avg("id") as aggregate from "users" group by "name"', array(), true)->andReturn(array(array('aggregate' => 3), array('aggregate' => 4)));
+		$builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function($builder, $results) { return $results; });
+		$results = $builder->from('users')->groupBy('name')->avg('id');
+		$this->assertEquals(3.5, $results);
+
+		$builder = $this->getBuilder();
+		$builder->getConnection()->shouldReceive('select')->once()->with('select avg("id") as aggregate from "users" group by "name"', array(), true)->andReturn(array());
+		$builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function($builder, $results) { return $results; });
+		$results = $builder->from('users')->groupBy('name')->avg('id');
+		$this->assertEquals(0, $results);
 	}
 
 


### PR DESCRIPTION
Calculates aggregate manually for grouped queries, to always return a scalar. This has the same effect as an SQL query using a subselect.

I think this makes more sense because it unifies the result type for both types of queries. Moreover, the array results are essentially useless in themselves as they do not have any information about which group they apply to.